### PR TITLE
Avoid relative import

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"./v5/pivotal"
 	"fmt"
 	"os"
 	"strconv"
 	"unicode/utf8"
+
+	"github.com/dav/go-pivotaltracker/v5/pivotal"
 )
 
 func doDumpPeople(client *pivotal.Client) error {


### PR DESCRIPTION
There are ways to make this work, but it complicates the story in our
internal libraries, since this package lives at
github.com/Shyp/<ourpackage>/vendor/github.com/dav/go-pivotaltracker,
the relative import of "v5/pivotal" doesn't work as easily.

It's a lot easier (and conventional) to use the full name space.